### PR TITLE
Removed commented out code from POM.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,9 +292,6 @@
               <trimStackTrace>false</trimStackTrace>
             </configuration>
           </execution>
-          <!-- <execution> <id>security-manager-test</id> <phase>integration-test</phase> <goals> <goal>test</goal> </goals> <configuration>
-            <includes> <include>**/*Test.java</include> </includes> <argLine>-Djava.security.manager -Djava.security.policy=${basedir}/src/test/resources/java.policy</argLine>
-            </configuration> </execution> -->
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
Commented out code in POM.xml which is totally unnecessary has been removed. 
Issue #22 Remove this commented out code in pom.xml
Issue URL: https://github.com/the-officialjosh/commons-lang/issues/22