### PR TITLE
Modified the public constructor of the utility class AnnotationUtils to private in order to prevent the instantiation 

### DIFF
--- a/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
+++ b/src/main/java/org/apache/commons/lang3/AnnotationUtils.java
@@ -347,12 +347,10 @@ public class AnnotationUtils {
      * {@link AnnotationUtils} instances should NOT be constructed in
      * standard programming. Instead, the class should be used statically.
      *
-     * <p>This constructor is public to permit tools that require a JavaBean
-     * instance to operate.</p>
-     * @deprecated TODO Make private in 4.0.
+     * <p>Earlier this constructor was public to permit tools that require a JavaBean
+     * instance to operate. To prevent it from being instantiated, now defining it as a private constructor.</p>
      */
-    @Deprecated
-    public AnnotationUtils() {
-        // empty
+    private AnnotationUtils() {
+        throw new IllegalStateException("Utility class");
     }
 }


### PR DESCRIPTION
Modified the constructor of the class AnnotationUtils and made it private to prevent the class from being instantiated.Earlier this constructor was public to permit tools that require a JavaBean. Since the utility class should be used statically, if any attempt to create a new instance will be prevented by the new code below:

private AnnotationUtils() {
     throw new IllegalStateException("Utility class");
    }
Issue Link: https://github.com/the-officialjosh/commons-lang/issues/34


