### PR TITLE
Fixes 54: Changed ArraySorter constructor private

### DIFF
--- a/src/main/java/org/apache/commons/lang3/ArraySorter.java
+++ b/src/main/java/org/apache/commons/lang3/ArraySorter.java
@@ -163,7 +163,7 @@ public class ArraySorter {
      * @deprecated Will be removed in 4.0.0.
      */
     @Deprecated
-    public ArraySorter() {
+    private ArraySorter() {
         // empty
     }
 


### PR DESCRIPTION
This pull request resolves the technical debt identified in issue #54.

Changes Made: The constructor for the `ArraySorter.java` utility class has been changed from `public` to `private`.

Reason for changes: Utility classes are not meant to be instantiated. Making the constructor private enforces this rule and removes the code smell reported by SonarQube.