### PR TITLE
Fix SpotBugs vulnerability: return defensive copy of TimeZone

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -963,7 +963,7 @@ public class FastDateParser implements DateParser, Serializable {
      */
     @Override
     public TimeZone getTimeZone() {
-        return timeZone;
+        return (TimeZone) timeZone.clone();
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a SpotBugs malicious code vulnerability detected in
FastDateParser.getTimeZone().

SpotBugs reported:

“May expose internal representation by returning reference to mutable object.”

The method was returning the internal TimeZone instance directly. Since TimeZone is mutable, external callers could unintentionally or maliciously modify internal state.

Fix applied:

A defensive copy of the TimeZone object is now returned using:

return (TimeZone) timeZone.clone();
This ensures the method no longer exposes internal mutable state and satisfies the SpotBugs security rule.

Tools used:
SpotBugs (IntelliJ plugin)
FindSecBugs security rules