### PR TITLE
Fix SpotBugs vulnerability: return defensive copy of TimeZone

### DIFF
--- a/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
+++ b/src/main/java/org/apache/commons/lang3/time/FastDateParser.java
@@ -963,7 +963,7 @@ public class FastDateParser implements DateParser, Serializable {
      */
     @Override
     public TimeZone getTimeZone() {
-        return timeZone;
+        return (TimeZone) timeZone.clone();
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a SpotBugs malicious code vulnerability in the FastDateParser.getTimeZone() method.
SpotBugs (FindSecBugs rules) reported that the method was exposing an internal mutable object by directly returning the TimeZone instance.

Issue Identified (SpotBugs)

"May expose internal representation by returning reference to mutable object"

The original implementation returned the internal timeZone field directly. Since TimeZone is a mutable class, external callers could unintentionally or maliciously modify the internal state of FastDateParser.

Fix Applied
A defensive copy of the TimeZone object is now returned:

return (TimeZone) timeZone.clone();


This ensures the method no longer exposes internal mutable state and fully satisfies the SpotBugs security rule.

Tools Used

SpotBugs (IntelliJ plugin)

FindSecBugs security rules

This fix resolves the vulnerability reported in Issue #63 .