### PR TITLE
test: suppress false positive ReDoS warning in RegExUtilsTest

### DIFF
--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
  */
 class RegExUtilsTest extends AbstractLangTest {
 
+    @SuppressWarnings("java:S5852") // Safe: Possessive quantifiers (++) used to prevent backtracking
     private static final Pattern WHITESPACE_AND_LETTERS = Pattern.compile("( ++)([a-z]++)");
 
     @Test


### PR DESCRIPTION
Resolves SonarQube security hotspot (java:S5852).

The regex constant was previously updated to use possessive quantifiers (++) which mitigates backtracking, but the static analyzer continues to flag it.

Added @SuppressWarnings("java:S5852") to the constant definition to resolve the false positive.


