### PR TITLE
Replace e.printStackTrace() with standard logging and control its output via a configuration check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
       <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>2.0.17</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <distributionManagement>
     <site>

--- a/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java
@@ -34,7 +34,8 @@ import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.function.Function;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.AbstractLangTest;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ import org.junit.jupiter.api.Test;
  * Tests {@link org.apache.commons.lang3.math.NumberUtils}.
  */
 class NumberUtilsTest extends AbstractLangTest {
-
+    private static final Logger LOG = LoggerFactory.getLogger(NumberUtilsTest.class);
     private static void assertCreateNumberZero(final String number, final Object zero, final Object negativeZero) {
         assertEquals(zero, NumberUtils.createNumber(number), () -> "Input: " + number);
         assertEquals(zero, NumberUtils.createNumber("+" + number), () -> "Input: +" + number);
@@ -107,7 +108,8 @@ class NumberUtilsTest extends AbstractLangTest {
             return true;
         } catch (final Exception e) {
             if (!s.matches(".*\\s.*")) {
-                e.printStackTrace();
+                // Replace e.printStackTrace() with a debug or trace level log
+                LOG.debug("Exception encountered during isApplyNonNull check for string: {}", s, e);
             }
             return false;
         }

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,35 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.apache.commons.lang3.math.NumberUtilsTest" level="DEBUG" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Vulnerability: Insecure Configuration - Make sure the debug feature is deactivated before delivering the code in production.
Code Smell: Replace the use of e.printStackTrace() in class NumberUtilsTest with standard logging and control its output via a configuration check to satisfy security hotspot warning. 

Issue Link: https://github.com/the-officialjosh/commons-lang/issues/59

Fix: Replace the use of e.printStackTrace()with standard logging and control its output via a configuration check. As a better practice, SLF4J logging framework along with a logging config file log4j2.xml is used in the resolution. This allows you to configure the logging level (DEBUG, INFO, ERROR) which is the standard way to "deactivate" debug features in production.
The logging configuration file log4j2.xml is for setting the logging level for the class NumberUtilsTest to DEBUG or TRACE to see the output depends on the environment.